### PR TITLE
Add on_start_span callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ OpenTracing.global_tracer = TracerImplementation.new
 
 require 'rack/tracer'
 use Rack::Tracer
+```
+
+You can access the created span using
+```ruby
+env['rack.span']
+```
+
+You can also add a start span callback
+```ruby
+use Rack::Tracer, on_start_span: Proc.new {|span| do_something(span) }
+```
 
 ## Development
 

--- a/lib/rack/tracer.rb
+++ b/lib/rack/tracer.rb
@@ -5,9 +5,10 @@ module Rack
     REQUEST_URI = 'REQUEST_URI'.freeze
     REQUEST_METHOD = 'REQUEST_METHOD'.freeze
 
-    def initialize(app, tracer = OpenTracing.global_tracer)
+    def initialize(app, tracer: OpenTracing.global_tracer, on_start_span: nil)
       @app = app
       @tracer = tracer
+      @on_start_span = on_start_span
     end
 
     def call(env)
@@ -24,6 +25,10 @@ module Rack
           'http.uri' => env[REQUEST_URI] # For zipkin, not OT convention
         }
       )
+
+      if @on_start_span
+        @on_start_span.call(span)
+      end
 
       env['rack.span'] = span
 

--- a/rack-tracer.gemspec
+++ b/rack-tracer.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'rack-tracer'
-  spec.version       = '0.1.0'
+  spec.version       = '0.2.0'
   spec.authors       = ['SaleMove TechMovers']
   spec.email         = ['techmovers@salemove.com']
 

--- a/rack-tracer.gemspec
+++ b/rack-tracer.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'logasm-tracer', '~> 0.2.0'
+  spec.add_development_dependency 'logasm-tracer', '~> 0.2.1'
   spec.add_development_dependency 'rack', '~> 2.0'
 end


### PR DESCRIPTION
This is useful when integrating with other tracing libaries. E.g.
```ruby
use Rack::Tracer, on_start_span: Proc.new {|span| Freddy.trace = span}
```